### PR TITLE
Update extract_from_osx.sh

### DIFF
--- a/firmware/extract_from_osx.sh
+++ b/firmware/extract_from_osx.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-IN=AppleCameraInterface
+IN=/System/Library/Extensions/AppleCameraInterface.kext/Contents/MacOS/AppleCameraInterface
 OUT=firmware.bin
 
-OSX_HASH=d1db66d71475687a5873dab10a345e2d
+OSX_HASH=ccea5db116954513252db1ccb639ce95
 FW_HASH=4e1d11e205e5c55d128efa0029b268fe
-HASH=$(md5sum $IN | awk '{ print $1 }')
+HASH=$(md5 -r $IN | awk '{ print $1 }')
 
 OFFSET=81920
 SIZE=603715
@@ -21,7 +21,7 @@ echo -e "Found matching hash ($HASH)"
 dd bs=1 skip=$OFFSET count=$SIZE if=$IN of=$OUT.gz &> /dev/null
 gunzip $OUT.gz
 
-RESULT=$(md5sum $OUT | awk '{ print $1 }')
+RESULT=$(md5 -r $OUT | awk '{ print $1 }')
 
 if [ "$RESULT" != "$FW_HASH" ]
 then


### PR DESCRIPTION
Use of native md5 -r instead of md5sum
Proper OSX_HASH for 10.11.2
Exact IN path on OSX 10.11.2